### PR TITLE
feat: page 404 if wrong id sent

### DIFF
--- a/src/pages/CarDescription.tsx
+++ b/src/pages/CarDescription.tsx
@@ -21,6 +21,10 @@ export function CarDescription() {
   const item = products.find((el) => el.id === itemId);
   const navigate = useNavigate();
 
+  if (!item) {
+    navigate('/NotFound');
+  }
+
   const addToCartHandler = () => {
     if (item) {
       onAddCartItem(item);

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -5,9 +5,13 @@ export function NotFound() {
   let arrHref = href.split('?');
   arrHref = arrHref[0].split('/');
   let hrefText = arrHref[arrHref.length - 1];
-  const hrefTextArr = hrefText.split('');
-  if (hrefTextArr.length > 9) {
-    hrefText = hrefTextArr.splice(0, 7).join('') + '...';
+  if (!hrefText || hrefText === 'NotFound') {
+    hrefText = 'such page';
+  } else {
+    const hrefTextArr = hrefText.split('');
+    if (hrefTextArr.length > 9) {
+      hrefText = hrefTextArr.splice(0, 7).join('') + '...';
+    }
   }
 
   return (


### PR DESCRIPTION
Если ввести некорректный id вручную в строку навигации, то выходила ошибка 404 дефолтная, а не созданная. Исправлено.